### PR TITLE
switch workflow to r2u

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -21,15 +21,12 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: '4.2.0'
+      - name: Setup r2u
+        uses: eddelbuettel/github-actions/r2u-setup@master
 
-      - name: install fwildclusterboot for testing
-        run: Rscript -e 'install.packages("fwildclusterboot", repos="https://cloud.r-project.org")'
+      - name: install R packages
+        run: Rscript -e 'install.packages(c("fwildclusterboot"))'
         shell: bash
-
 
       - name: Setup python
         uses: actions/setup-python@v2


### PR DESCRIPTION
- Switches the github action to [r2u](https://github.com/eddelbuettel/r2u), which allows to install pre-built binaries of R packages on Linux. I use this for pyfixest and it saves a massive amount of time in the CI runs, as fwildclusterboot / other R packages do not need to be compiled from scratch.
- Also, it still installs rwolf in the pyfixest wfl, which depends on fwildclusterboot and is also no longer on CRAN. So maybe it fixes #108 temporarily =) 