### PR TITLE
Raise if unsupported

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ pymdown-extensions = ">=10.0"
 mkdocstrings-python-legacy = "^0.2.3"
 mkdocstrings = {version = "^0.19.0", extras = ["python"], optional = true }
 pymdown-extensions = ">=10.0"
+rpy2 = "^3.5.16"
 
 
 [build-system]

--- a/tests/test_seeds.py
+++ b/tests/test_seeds.py
@@ -44,3 +44,16 @@ def test_results_from_same_seed(data):
         np.random.seed(123)
         b2 = wildboottest(model, param = "X1", cluster = x, B= 999)
         pd.testing.assert_frame_equal(a2,b2)
+
+def test_seeds_and_rng(data):
+    model = sm.ols(formula='Y ~ X1 + X2', data=data)    
+
+    cluster_list = [data.cluster, None]
+    
+    for x in cluster_list: 
+
+        # specifying seed and rng with that seed -> same results
+        a = wildboottest(model, param = "X1", cluster = x, B= 999, seed=876587)
+        rng = np.random.default_rng(seed=876587)
+        b = wildboottest(model, param = "X1", cluster = x, B= 999, seed=rng)
+        pd.testing.assert_frame_equal(a,b)

--- a/tests/test_weights.py
+++ b/tests/test_weights.py
@@ -4,7 +4,6 @@ from wildboottest.wildboottest import WildboottestCL
 import numpy as np
 import pandas as pd
 
-np.random.seed(89756)
 
 ts = list(wild_draw_fun_dict.keys())
 full_enum = [True, False]
@@ -13,6 +12,7 @@ boot_iter = list(range(0,1000,400))
 
 @pytest.fixture
 def data():
+    np.random.seed(12315)
     N = 100
     k = 2
     G= 20
@@ -46,9 +46,11 @@ def test_different_weights(data):
     X, y, cluster, bootcluster, R, B = data
     
     results_dict = {}
+    
+    rng = np.random.default_rng(seed=0)
 
     for w in ts:
-        boot = WildboottestCL(X = X, Y = y, cluster = cluster, bootcluster = bootcluster, R = R, B = 99999, seed = 12341)
+        boot = WildboottestCL(X = X, Y = y, cluster = cluster, bootcluster = bootcluster, R = R, B = 99999, seed = rng)
         boot.get_scores(bootstrap_type = "11", impose_null = True)
         boot.get_weights(weights_type = w)
         boot.get_numer()
@@ -60,7 +62,9 @@ def test_different_weights(data):
         results_dict[w] = boot.pvalue
         
     results_series = pd.Series(results_dict)
+    print(results_series)
 
     mapd = (results_series - results_series.mean()).abs().mean()  / results_series.mean()    
+    print(mapd)
         
     assert  mapd <= .1# make sure mean absolute percentage deviation is less than 10% (ad hoc)

--- a/wildboottest/wildboottest.py
+++ b/wildboottest/wildboottest.py
@@ -6,6 +6,12 @@ from wildboottest.weights import draw_weights
 import warnings
 from typing import Union, Tuple, Callable
 from numpy.random import Generator
+from statsmodels.regression.linear_model import OLS
+
+
+_allowed_models = (
+  OLS,
+)
 
 class WildDrawFunctionException(Exception):
     pass
@@ -649,7 +655,7 @@ class WildboottestCL:
       self.pvalue = np.mean(self.t_stat > self.t_boot)
 
 
-def wildboottest(model : 'OLS',
+def wildboottest(model : OLS,
                  B:int,
                  cluster : Union[np.ndarray, pd.Series, pd.DataFrame, None] = None,
                  param : Union[str, None] = None,
@@ -713,6 +719,9 @@ def wildboottest(model : 'OLS',
       >>> wildboottest(model, param = "X1", cluster = cluster, B = 9999)
       >>> wildboottest(model, cluster = cluster, B = 9999)
   """
+  
+  if not isinstance(model, _allowed_models):
+    raise NotImplementedError(f"Only allow models of type {' ,'.join([str(i) for i in _allowed_models])}")
 
   # does model.exog already exclude missing values?
   X = model.exog


### PR DESCRIPTION
- Raises `NotImplementedError` is a model not in the `allowed_models` tuple isn't input into `wildboottest`

Fixes #58.